### PR TITLE
Correctly set product___NODE on ProductMetafieldNode

### DIFF
--- a/src/nodes/product.ts
+++ b/src/nodes/product.ts
@@ -58,7 +58,7 @@ interface ProductMetafieldNode extends MetafieldNodeFragment {
 const ProductMetafieldNode = createNodeFactory(
   NodeType.PRODUCT_METAFIELD,
   async (node: ProductMetafieldNode, productId: string) => {
-    node.product___NODE = generateNodeId(NodeType.PRODUCT_VARIANT, productId);
+    node.product___NODE = generateNodeId(NodeType.PRODUCT, productId);
 
     return node;
   },
@@ -109,7 +109,7 @@ export async function createProductNode(
   // Create all metafield nodes
   await Promise.all(
     product.metafields.edges
-      .map((edge) => ProductMetafieldNode(edge.node))
+      .map((edge) => ProductMetafieldNode(edge.node, product.id))
       .map((p) => p.then(createNode)),
   );
 


### PR DESCRIPTION
Hey @qw-in - great effort with this, our builds with `gatsby-source-shopify` take forever, so having an incremental build is invaluable.

Currently, when metafields are included against a product, Gatsby throws the following invariant violation error.

> Encountered an error trying to infer a GraphQL type for: `product___NODE`. There is no corresponding node with the `id` field matching: “Shopify__ProductVariant__undefined”.

I tracked it down to `ProductMetafieldNode` where the following issues were present:

1. Should be using `NodeType.PRODUCT` but was using `NodeType.PRODUCT_VARIANT`
2. The `productId` attribute was not being provided, resulting in the `undefined`

This PR fixes the above and our builds are now running correctly with product metafields included.