### PR TITLE
Reduce storefront page size to 100

### DIFF
--- a/src/queries/util.ts
+++ b/src/queries/util.ts
@@ -38,7 +38,7 @@ export function fetchAllNodesFactory<T>(fetcher: NodesFetcher<T>) {
       client,
       {
         ...variables,
-        first: 150,
+        first: 100,
       },
       page,
     );
@@ -53,7 +53,7 @@ export function fetchAllNodesFactory<T>(fetcher: NodesFetcher<T>) {
           client,
           {
             ...variables,
-            first: 150,
+            first: 100,
             after: edges[edges.length - 1].cursor,
           },
           page,


### PR DESCRIPTION
Due to the level of nesting used by the query (products > variants > metafields) and other collections attached to the product, we are finding that a page size of 150 consistently times out the Storefront API on stores with a large number of products.

Lowering the page size to 100 resolves the timeouts and leads to a much faster build time (since it doesn't need to retry the same page).

It would be great if this were configurable in the plugin settings, as could be adjusted depending on the size of the product collection.