### PR TITLE
Admin API error interceptor

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -45,6 +45,16 @@ export function createClient(
     },
   });
 
+  admin.interceptors.response.use(
+    function (response) {
+      if (response.data.errors) {
+        throw new Error(`Shopify admin API responded with error: ${JSON.stringify(response.data.errors)}`)
+      }
+
+      return response;
+    }
+  );
+
   const storefrontClient = axios.create({
     baseURL: `https://${storefrontShopDomain}/api/${apiVersion}/graphql`,
     method: 'post',


### PR DESCRIPTION
We ran into an issue where we had set our admin API scopes incorrectly, such that the "incremental" request for products was failing as it couldn't access the published status of the product.

The error output for this scenario was the below, which comes from [here](https://github.com/dignified-org/gatsby-source-shopify-incremental/blob/main/src/admin/product-updates.ts#L44) assuming that products have been returned in the response.

> TypeError: Cannot read property 'products' of null

Often, Shopify will return 200 OK but will include errors in `data.errors`, omitting the `data.[key]` such that `data.products` would not exist.

To make it easier to debug issues with the admin API, I have added an interceptor to the admin axios instance, such that if `response.data.errors` exists, an exception is thrown with the detail and will properly exit the process.

With the interceptor in place, the following is thrown as an error instead.

> Error: Shopify admin API responded with error: [{"message":"access denied","locations":[{"l  ine":15,"column":11}],"path":["products","edges",0,"node","published"]}]